### PR TITLE
Event date in narrow views is obscured by org logo

### DIFF
--- a/sass/_tables.sass
+++ b/sass/_tables.sass
@@ -247,7 +247,7 @@ details[open] + .card
 
     .header, .entry
       grid-template-columns: subgrid
-      grid-template-rows: 1lh auto
+      grid-template-rows: auto auto
       grid-column: span 2
 
       .d


### PR DESCRIPTION
Fix with `grid-template-rows: auto auto`